### PR TITLE
Supports concurrency for faster scanning and cross platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # openssl-3.0-check
 Tools for helping address the vulnerability addressed by OpenSSL 3.0.7 on 11/1/2022 https://mta.openssl.org/pipermail/openssl-announce/2022-October/000238.html
 
-openssl-check.sh - Uses ldd to determine which executables on a Linux system may be dynamically linked to OpenSSL 3.x
+openssl-check.sh - Uses ldd to determine which executables on a Linux/BSD/MacOS system may be dynamically linked to OpenSSL 3.x

--- a/openssl-check.sh
+++ b/openssl-check.sh
@@ -44,16 +44,16 @@ fi
 
 if [[ "${DEPTH}" -gt 2 ]]; then
   echo "you probably don't want to do > 2 (default). [enter to continue]"
-  #read
+  read
 fi
 
 echo "Running with: [${MAX_RUNNING}]:Jobs [${DEPTH}]:Depth"
 
-#if [ ${UID} -ne 0 ]
-#then
-#        echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
-#        read
-#fi
+if [ ${UID} -ne 0 ]
+then
+        echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
+        read
+fi
 
 if [[ "${os}" == 'linux' || "${os}" == *"bsd"* ]]; then
   LDD=$(which ldd)

--- a/openssl-check.sh
+++ b/openssl-check.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # License GPL
 # Copyright 2022 Omkhar Arasaratnam
-
-#set -x 
+#   sexified by Rob Dailey
 
 function cleanup_kids { 
   for job in $(jobs -lp); do
@@ -35,7 +34,7 @@ if [[ "${MAX_RUNNING}" == 0 ]]; then
 
   if [[ "${MAX_RUNNING}" == 0 ]]; then
     MAX_RUNNING=$(sysctl hw.ncpu 2>/dev/null | tr -cd '[:digit:]')
-    MAX_RUNNING=$(( ${MAX_RUNNING:-"4"} / 8 ))
+    MAX_RUNNING=$(( ${MAX_RUNNING:-"4"} / 4 ))
     if [[ "${MAX_RUNNING}" -lt "4" ]]; then
       MAX_RUNNING=4  # seems to be optimal min
     fi
@@ -49,36 +48,42 @@ fi
 
 echo "Running with: [${MAX_RUNNING}]:Jobs [${DEPTH}]:Depth"
 
-if [ ${UID} -ne 0 ]
-then
-        echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
-        read
+if [[ ${UID} -ne 0 ]]; then
+  echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
+  read
 fi
 
-if [[ "${os}" == 'linux' || "${os}" == *"bsd"* ]]; then
+if [[ "${os}" == 'linux' ]];then 
   LDD=$(which ldd)
+  WHICH_LDD_EXIT=$?
   LIB="libssl.so.3"
+elif [[ "${os}" == *"bsd"* ]]; then
+  LDD=$(which ldd)
+  WHICH_LDD_EXIT=$?
+  LIB="libssl.so.3"
+  LOCALS_ONLY="-fstype local"
 elif [[ "${os}" == 'darwin' ]]; then
   LDD=$(which otool)
+  WHICH_LDD_EXIT=$?
   LDD_FLAGS="-L"
   LIB="libssl.3.dylib"
+  LOCALS_ONLY="-fstype local"
 else
   echo "unsupported OS [${os}]"
   exit 1
 fi
 
-if [[ -z "${LDD}" ]]; then
+if [[ "${WHICH_LDD_EXIT}" -ne 0 ]]; then
   echo "Couldn't find ldd, exiting"
   exit 1
 fi
 
 
-FIND=`which find`
-EXIT=$?
-if [ ${EXIT} -ne 0 ]
-then
-        echo "Couldn't find find, exiting"
-        exit 1
+FIND=$(which find)
+WHICH_FIND_EXIT=$?
+if [[ ${WHICH_FIND_EXIT} -ne 0 ]]; then
+  echo "Couldn't find find, exiting"
+  exit 1
 fi
 
 
@@ -129,7 +134,7 @@ while read -r dir_path; do
     wait -n
   done
 
-done < <(find / -fstype local -maxdepth ${DEPTH} \( -path "/proc" -o -path "/System/Volumes/Data" \) -prune -o -type d -print 2>/dev/null | sort -r)
+done < <(find / -maxdepth ${DEPTH} \( -path "/proc" -o -path "/System/Volumes" \) -prune -o ${MAC_LOCALS_ONLY} -type d -print 2>/dev/null | sort -r)
 
 # catch any leftover files
 while read -r dir_path; do

--- a/openssl-check.sh
+++ b/openssl-check.sh
@@ -1,35 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # License GPL
-# Copyright 2022 Omkhar Arasaratnam 
+# Copyright 2022 Omkhar Arasaratnam
+#   Made sexier by Rob Dailey
+
+MAX_RUNNING=$(cat /proc/cpuinfo0 2>/dev/null | grep -c processor)
+if [[ ${MAX_RUNNING} == 0 ]]; then
+  MAX_RUNNING=$(sysctl hw.ncpu 2>/dev/null | tr -cd '[:digit:]')
+  MAX_RUNNING=$((${MAX_RUNNING:-"4"} / 2))
+fi
+echo "Running with [${MAX_RUNNING}] Jobs"
 
 if [ ${UID} -ne 0 ]
 then
-	echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
-	read
+  echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
+  read
 fi
 
 LDD=`which ldd`
 EXIT=$?
 if [ ${EXIT} -ne 0 ]
 then
-	echo "Couldn't find ldd, exiting"
-	exit 1
+  echo "Couldn't find ldd, exiting"
+  exit 1
 fi
 
 FIND=`which find`
 EXIT=$?
 if [ ${EXIT} -ne 0 ]
 then
-	echo "Couldn't find find, exiting"
-	exit 1
+  echo "Couldn't find find, exiting"
+  exit 1
 fi
 
-for FILE in `${FIND} / -type f -executable -print`
-do
-  ${LDD} ${FILE} 2> /dev/null | grep -i "libssl.so.3" &> /dev/null
-  EXIT=$?
-  if [ ${EXIT} -eq 0 ]
-  then
-    echo "${FILE} may be dynamically linked to openssl-3.x"
+function run_parallel {
+
+  ${FIND} ${1} ${@:2} -type f -perm -a=x -print0 2>/dev/null |
+     xargs -0 -I FILE_NAME sh -c "${LDD} \"FILE_NAME\" 2>/dev/null | grep -Iq libssl.so.3 2>/dev/null && echo \"FILE_NAME may be dynamically linked to openssl-3.x\"" &
+
+  SELF_RUNNING=$(jobs | wc -l | sed 's/[ \t]*//')
+  if [[ $SELF_RUNNING -ge ${MAX_RUNNING} ]]; then
+    wait -n
   fi
-done
+
+}
+
+PREV=""
+# hit all the dirs
+while read -r dir_path; do
+  if [[ "${dir_path}" == "/" ]]; then
+      continue
+  fi
+  if [[ "${PREV}" == "${dir_path}" ]];  then
+      run_parallel ${dir_path} -maxdepth 1 ! -type d
+  else
+      run_parallel ${dir_path}
+  fi
+  PREV=$(dirname ${dir_path})
+done < <(find / -maxdepth 2 -type d 2>/dev/null | sort -r)
+
+# catch any leftover files
+while read -r dir_path; do
+  run_parallel ${dir_path}
+done < <(find / -maxdepth 1 ! -type d 2>/dev/null)
+
+wait
+echo -e "\n[fin]"

--- a/openssl-check.sh
+++ b/openssl-check.sh
@@ -1,67 +1,98 @@
 #!/usr/bin/env bash
 # License GPL
 # Copyright 2022 Omkhar Arasaratnam
-#   Made sexier by Rob Dailey
+#   - made sexier by rob dailey
+
+DEPTH=${1:-2}
+PREV=""
+BASE_EXCLUDES=""
+declare -A BASE_EXCLUDES
+
+PID=$$
+echo "PID: ${PID}"
 
 MAX_RUNNING=$(cat /proc/cpuinfo0 2>/dev/null | grep -c processor)
 if [[ ${MAX_RUNNING} == 0 ]]; then
   MAX_RUNNING=$(sysctl hw.ncpu 2>/dev/null | tr -cd '[:digit:]')
-  MAX_RUNNING=$((${MAX_RUNNING:-"4"} / 2))
+  MAX_RUNNING=$((${MAX_RUNNING:-4} / 2))
 fi
 echo "Running with [${MAX_RUNNING}] Jobs"
 
 if [ ${UID} -ne 0 ]
 then
-  echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
-  read
+        echo "Not running as root, we may not be able to read all binaries on the system [enter to continue]"
+        read
+fi
+
+if [ ${DEPTH} -gt 2 ]; then
+    echo "Don't run more than 2 deep unless you know something special ... it gets slower (currently) [enter to continue]"
+    read
 fi
 
 LDD=`which ldd`
 EXIT=$?
 if [ ${EXIT} -ne 0 ]
 then
-  echo "Couldn't find ldd, exiting"
-  exit 1
+        echo "Couldn't find ldd, exiting"
+        exit 1
 fi
 
 FIND=`which find`
 EXIT=$?
 if [ ${EXIT} -ne 0 ]
 then
-  echo "Couldn't find find, exiting"
-  exit 1
+        echo "Couldn't find find, exiting"
+        exit 1
 fi
+
 
 function run_parallel {
 
-  ${FIND} ${1} ${@:2} -type f -perm -a=x -print0 2>/dev/null |
-     xargs -0 -I FILE_NAME sh -c "${LDD} \"FILE_NAME\" 2>/dev/null | grep -Iq libssl.so.3 2>/dev/null && echo \"FILE_NAME may be dynamically linked to openssl-3.x\"" &
-
-  SELF_RUNNING=$(jobs | wc -l | sed 's/[ \t]*//')
+  SELF_RUNNING=$(jobs | wc -l | tr -cd '[:digit:]')
   if [[ $SELF_RUNNING -ge ${MAX_RUNNING} ]]; then
     wait -n
   fi
 
+  ${FIND} ${1} ${@:2} -type f -perm -a=x -print0 2>/dev/null |
+      xargs -0 -I FILE_NAME sh -c "(${LDD} \"FILE_NAME\" 2>/dev/null | grep -q libssl.so.3 2>/dev/null) && echo \"FILE_NAME may be dynamically linked to openssl-3.x\"" &
+
 }
 
-PREV=""
 # hit all the dirs
 while read -r dir_path; do
   if [[ "${dir_path}" == "/" ]]; then
       continue
   fi
+
+  # get our hash key
+  IFS='\/' read -ra split_path <<< "${dir_path}"
+  unset split_path[0] # clean null
+  _BASE="${split_path[@]:0:${DEPTH}+1}" # we index at 0
+  _BASE=$(sed -e 's/^[[:space:]]*//'<<<"${_BASE}")
+
   if [[ "${PREV}" == "${dir_path}" ]];  then
-      run_parallel ${dir_path} -maxdepth 1 ! -type d
+      run_parallel ${dir_path} -maxdepth 1 ! -type d ${BASE_EXCLUDES[${_BASE}]}
   else
+      # not a top level path
       run_parallel ${dir_path}
+
   fi
+  BASE_EXCLUDES[${_BASE}]="${BASE_EXCLUDES[${_BASE}]} -name \"${dir_path}\" -prune -o"
   PREV=$(dirname ${dir_path})
-done < <(find / -maxdepth 2 -type d 2>/dev/null | sort -r)
+
+  _skip_tree=""
+  for _skip_base in "${split_path[@]}"; do
+      _skip_tree="${_skip_tree} ${_skip_base}"
+      _skip_tree=$(sed -e 's/^[[:space:]]*//'<<<"${_skip_tree}")
+      BASE_EXCLUDES[${_skip_tree}]="${BASE_EXCLUDES[${_skip_tree}]} ${BASE_EXCLUDES[${_BASE}]}"
+  done
+
+done < <(find / -maxdepth ${DEPTH} -type d -name "/proc" -prune -o -print 2>/dev/null | sort -r)
 
 # catch any leftover files
 while read -r dir_path; do
   run_parallel ${dir_path}
-done < <(find / -maxdepth 1 ! -type d 2>/dev/null)
+done < <(find / -maxdepth 1 ! -type d 2>/dev/null )
 
 wait
 echo -e "\n[fin]"


### PR DESCRIPTION
- Modified tooling to add support for BSD (tested FreeBSD 13.1) and MacOS (tested Ventura)
- Now concurrent. Attempts to check CPU count to determine how many concurrent jobs to process (defaults to 4 on failure)

Improved speeds:

- Pi 4b w/ SD card: ~33%
- FBSD w/ multiple drive array ZFS: ~142%

If I can figure out how to clean up the root tree traversal more, I can squeeze more out.
